### PR TITLE
Distribute data across multiple database clusters

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,12 +1,114 @@
 import mongoose from "mongoose";
 
-export const MentorDB = async () => {
-	try {
-		const conn = await mongoose.connect(process.env.MENTOR_URI);
-		console.log(`MongoDB Connected: ${conn.connection.host}`);
-	} catch (error) {
-		console.error(`Error: ${error.message}`);
-		process.exit(1); // process code 1 code means exit with failure, 0 means success
-	}
-};
+// Registry of named mongoose connections
+const connectionRegistry = new Map(); // name -> mongoose.Connection
+
+function parseClusterConfig() {
+    // Supports either:
+    // - MONGO_URIS: "primary=mongodb://...;eu=mongodb://..."
+    // - DB_CLUSTERS: "primary,eu" with envs MONGO_URI_PRIMARY, MONGO_URI_EU
+    // - MENTOR_URI or MONGO_URI (single cluster fallback => "primary")
+    const entries = [];
+
+    const urisList = process.env.MONGO_URIS;
+    if (urisList && urisList.trim().length > 0) {
+        for (const pair of urisList.split(";")) {
+            const [rawName, ...rest] = pair.split("=");
+            const name = (rawName || "").trim();
+            const uri = rest.join("=").trim();
+            if (name && uri) entries.push({ name, uri });
+        }
+    }
+
+    if (entries.length === 0) {
+        const rawNames = process.env.DB_CLUSTERS;
+        if (rawNames && rawNames.trim().length > 0) {
+            for (const rawName of rawNames.split(",")) {
+                const name = rawName.trim();
+                if (!name) continue;
+                const envKey = `MONGO_URI_${name.toUpperCase()}`;
+                const uri = process.env[envKey];
+                if (!uri) {
+                    console.warn(`Missing ${envKey} for cluster '${name}'`);
+                    continue;
+                }
+                entries.push({ name, uri });
+            }
+        }
+    }
+
+    if (entries.length === 0) {
+        const singleUri = process.env.MENTOR_URI || process.env.MONGO_URI;
+        if (singleUri) entries.push({ name: "primary", uri: singleUri });
+    }
+
+    return entries;
+}
+
+export async function connectClusters() {
+    const clusterEntries = parseClusterConfig();
+    if (clusterEntries.length === 0) {
+        throw new Error(
+            "No MongoDB URI(s) found. Define MONGO_URIS or DB_CLUSTERS + MONGO_URI_<NAME> or MONGO_URI/MENTOR_URI."
+        );
+    }
+
+    const connectPromises = clusterEntries.map(async ({ name, uri }) => {
+        if (connectionRegistry.has(name)) return connectionRegistry.get(name);
+        const connection = mongoose.createConnection(uri);
+        // Await initial connection
+        await connection.asPromise();
+        connection.on("error", (err) => {
+            console.error(`[mongo:${name}] error`, err);
+        });
+        connection.on("disconnected", () => {
+            console.warn(`[mongo:${name}] disconnected`);
+        });
+        console.log(`[mongo:${name}] connected: ${connection.host}`);
+        connectionRegistry.set(name, connection);
+        return connection;
+    });
+
+    await Promise.all(connectPromises);
+}
+
+export function getConnection(requestedName = "primary") {
+    if (connectionRegistry.size === 0) {
+        throw new Error("Database clusters not initialized. Call connectClusters() first.");
+    }
+
+    if (requestedName && connectionRegistry.has(requestedName)) {
+        return connectionRegistry.get(requestedName);
+    }
+
+    // Fallbacks: DEFAULT_DB_CLUSTER or the sole/first available connection
+    const defaultName = process.env.DEFAULT_DB_CLUSTER;
+    if (defaultName && connectionRegistry.has(defaultName)) {
+        return connectionRegistry.get(defaultName);
+    }
+
+    if (connectionRegistry.size === 1) {
+        return [...connectionRegistry.values()][0];
+    }
+
+    // As last resort, return "primary" if present or undefined
+    return connectionRegistry.get("primary");
+}
+
+export function getClusterNames() {
+    return [...connectionRegistry.keys()];
+}
+
+export function getModel(connection, modelName, schema) {
+    if (!connection) throw new Error("Connection is required to get model");
+    if (connection.models[modelName]) return connection.models[modelName];
+    return connection.model(modelName, schema);
+}
+
+export function getClusterFromRequest(req) {
+    const header = req.headers?.["x-cluster"] || req.headers?.["x-db-cluster"];
+    const query = req.query?.cluster;
+    const selected = header || query || process.env.DEFAULT_DB_CLUSTER || "primary";
+    return String(selected);
+}
 

--- a/backend/controllers/mentors.controller.js
+++ b/backend/controllers/mentors.controller.js
@@ -1,9 +1,13 @@
 import mongoose from "mongoose";
-import Mentors from "../models/mentors.model.js";
+import Mentors, { mentorsSchema } from "../models/mentors.model.js";
+import { getClusterFromRequest, getConnection, getModel } from "../config/db.js";
 
 export const getMentors = async (req, res) => {
 	try {
-		const mentors = await Mentors.find({});
+        const clusterName = getClusterFromRequest(req);
+        const conn = getConnection(clusterName);
+        const MentorsModel = getModel(conn, "Mentors", mentorsSchema);
+        const mentors = await MentorsModel.find({});
 		res.status(200).json({ success: true, data: mentors });
 	} catch (error) {
 		console.log("error in fetching mentors:", error.message);
@@ -18,10 +22,13 @@ export const createMentors = async (req, res) => {
 		return res.status(400).json({ success: false, message: "Please provide all fields" });
 	}
 
-	const newMentors = new Mentors(mentors);
+    try {
+        const clusterName = getClusterFromRequest(req);
+        const conn = getConnection(clusterName);
+        const MentorsModel = getModel(conn, "Mentors", mentorsSchema);
+        const newMentors = new MentorsModel(mentors);
 
-	try {
-		await newMentors.save();
+        await newMentors.save();
 		res.status(201).json({ success: true, data: newMentors });
 	} catch (error) {
 		console.error("Error in Create mentors:", error.message);
@@ -38,8 +45,11 @@ export const updateMentors = async (req, res) => {
 		return res.status(404).json({ success: false, message: "Invalid Mentors Id" });
 	}
 
-	try {
-		const updatedMentors = await Mentors.findByIdAndUpdate(id, mentors, { new: true });
+    try {
+        const clusterName = getClusterFromRequest(req);
+        const conn = getConnection(clusterName);
+        const MentorsModel = getModel(conn, "Mentors", mentorsSchema);
+        const updatedMentors = await MentorsModel.findByIdAndUpdate(id, mentors, { new: true });
 		res.status(200).json({ success: true, data: updatedMentors });
 	} catch (error) {
 		res.status(500).json({ success: false, message: "Server Error" });
@@ -53,8 +63,11 @@ export const deleteMentors = async (req, res) => {
 		return res.status(404).json({ success: false, message: "Invalid Mentors Id" });
 	}
 
-	try {
-		await Mentors.findByIdAndDelete(id);
+    try {
+        const clusterName = getClusterFromRequest(req);
+        const conn = getConnection(clusterName);
+        const MentorsModel = getModel(conn, "Mentors", mentorsSchema);
+        await MentorsModel.findByIdAndDelete(id);
 		res.status(200).json({ success: true, message: "Mentors deleted" });
 	} catch (error) {
 		console.log("error in deleting mentors:", error.message);

--- a/backend/models/mentors.model.js
+++ b/backend/models/mentors.model.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 
-const mentorsSchema = new mongoose.Schema(
+// Export schema to allow model creation per-connection
+export const mentorsSchema = new mongoose.Schema(
   {
     email: {
       type: String,
@@ -16,6 +17,7 @@ const mentorsSchema = new mongoose.Schema(
   },
 );
 
+// Backwards-compatible default export bound to the default mongoose connection.
+// In multi-cluster usage, prefer creating models per-connection via getModel().
 const Mentors = mongoose.model("Mentors", mentorsSchema);
-
 export default Mentors;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,7 @@ import express from "express";
 import dotenv from "dotenv";
 import path from "path";
 
-import { MentorDB } from "./config/db.js";
+import { connectClusters, getClusterNames } from "./config/db.js";
 
 import mentorsRoutes from "./routes/mentors.route.js";
 
@@ -24,8 +24,14 @@ if (process.env.NODE_ENV === "production") {
 	});
 }
 
-app.listen(PORT, () => {
-	MentorDB();
-	console.log("Server started at http://localhost:" + PORT);
+app.listen(PORT, async () => {
+    try {
+        await connectClusters();
+        console.log("DB clusters initialized:", getClusterNames());
+    } catch (err) {
+        console.error("Failed to initialize DB clusters:", err.message);
+        process.exit(1);
+    }
+    console.log("Server started at http://localhost:" + PORT);
 });
 


### PR DESCRIPTION
Add multi-cluster MongoDB support to enable routing requests to different database clusters.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5579613-29f3-43e2-a3b6-2eef75283874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5579613-29f3-43e2-a3b6-2eef75283874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

